### PR TITLE
resolves #43: Fixes error in addElementToBeginningOfArray test

### DIFF
--- a/test/arrays-test.js
+++ b/test/arrays-test.js
@@ -26,7 +26,7 @@ describe('arrays', () => {
 
       addElementToBeginningOfArray(array, 'foo')
 
-      expect(array).to.eql(array)
+      expect(array).to.eql([1])
     })
   })
 


### PR DESCRIPTION
@gj 

This test was passing because `array` still points to the same object in memory. We need to assert equality with an array literal to get the proper behavior.