### PR TITLE
ensure complete test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ iceCreams.slice(0, iceCreams.length - 1) // ["chocolate", "vanilla"]
 iceCreams // ["chocolate", "vanilla", "raspberry"]
 ```
 
-**TODO**: Define a function in `arrays.js` called `removeElementFromEndOfArray` that takes an array as its only argument and removes the last element. Your function should return the entire array, and it **should not** mutate the array.
+**TODO**: Define a function in `arrays.js` called `removeElementFromEndOfArray` that takes an array as its only argument and removes the last element. Your function should return the array without the last element, and it **should not** mutate the original array.
 
 ### From the Middle of an Array
 

--- a/test/arrays-test.js
+++ b/test/arrays-test.js
@@ -17,11 +17,11 @@ describe('arrays', () => {
   })
 
   describe('addElementToBeginningOfArray(array, element)', () => {
-    it('adds an `element` to the beginning of an `array`', () => {
+    it('adds an element to the beginning of an array', () => {
       expect(addElementToBeginningOfArray([1], 'foo')).to.eql(['foo', 1])
     })
 
-    it('does not alter `array`', () => {
+    it('does not alter the original array', () => {
       const array = [1]
 
       addElementToBeginningOfArray(array, 'foo')
@@ -31,11 +31,11 @@ describe('arrays', () => {
   })
 
   describe('destructivelyAddElementToBeginningOfArray(array, element)', () => {
-    it('adds an `element` to the beginning of an `array`', () => {
+    it('adds an element to the beginning of an array', () => {
       expect(destructivelyAddElementToBeginningOfArray([1], 'foo')).to.eql(['foo', 1])
     })
 
-    it('alters `array`', () => {
+    it('alters the original array', () => {
       const array = [1]
 
       destructivelyAddElementToBeginningOfArray(array, 'foo')
@@ -45,25 +45,25 @@ describe('arrays', () => {
   })
 
   describe('addElementToEndOfArray(array, element)', () => {
-    it('adds an `element` to the end of an `array`', () => {
+    it('adds an element to the end of an array', () => {
       expect(addElementToEndOfArray([1], 'foo')).to.eql([1, 'foo'])
     })
 
-    it('does not alter `array`', () => {
+    it('does not alter the original array', () => {
       const array = [1]
 
       addElementToEndOfArray(array, 'foo')
 
-      expect(array).to.eql(array)
+      expect(array).to.eql([1])
     })
   })
 
   describe('destructivelyAddElementToEndOfArray(array, element)', () => {
-    it('adds an `element` to the end of an `array`', () => {
+    it('adds an element to the end of an array', () => {
       expect(destructivelyAddElementToEndOfArray([1], 'foo')).to.eql([1, 'foo'])
     })
 
-    it('alters `array`', () => {
+    it('alters the original array', () => {
       const array = [1]
 
       destructivelyAddElementToEndOfArray(array, 'foo')
@@ -73,17 +73,17 @@ describe('arrays', () => {
   })
 
   describe('accessElementInArray(array, index)', () => {
-    it('accesses the element in `array` at the given `index`', () => {
+    it('accesses the element in array at the given index', () => {
       expect(accessElementInArray([1, 2, 3], 2)).to.equal(3)
     })
   })
   
   describe('destructivelyRemoveElementFromBeginningOfArray(array)', ()=>{
-    it('returns the `array` with the first element removed', () => {
+    it('returns the array with the first element removed', () => {
       expect(destructivelyRemoveElementFromBeginningOfArray([1, 2, 3])).to.eql([2, 3])
     })
     
-    it('did not make a copy of the array when removing the first element', ()=>{
+    it('alters the original array', ()=>{
       const array = [1, 2, 3];
       destructivelyRemoveElementFromBeginningOfArray(array);
       expect(array).to.eql([2, 3]);
@@ -91,17 +91,25 @@ describe('arrays', () => {
   })
 
   describe('removeElementFromBeginningOfArray(array)', () => {
-    it('removes the first element from the `array`', () => {
+    it('removes the first element from the array', () => {
       expect(removeElementFromBeginningOfArray([1, 2, 3])).to.eql([2, 3])
+    })
+
+    it('does not alter the original array', () => {
+      const array = [1, 2, 3];
+
+      removeElementFromBeginningOfArray(array);
+
+      expect(array).to.eql([1, 2, 3]);
     })
   })
 
   describe('destructivelyRemoveElementFromEndOfArray(array)', () => {
-    it('returns the `array` with the last element removed', () => {
+    it('returns the array with the last element removed', () => {
       expect(destructivelyRemoveElementFromEndOfArray([1, 2, 3])).to.eql([1, 2])
     })
     
-    it('did not make a copy of the array when removing the last element', ()=>{
+    it('alters the original array', ()=>{
       const array = [1, 2, 3];
       destructivelyRemoveElementFromEndOfArray(array);
       expect(array).to.eql([1, 2]);
@@ -109,8 +117,14 @@ describe('arrays', () => {
   })
   
   describe('removeElementFromEndOfArray(array)', () => {
-    it('removes the last element from the `array`', () => {
+    it('removes the last element from the array', () => {
       expect(removeElementFromEndOfArray([1, 2, 3])).to.eql([1, 2])
+    })
+    
+    it('does not alter the original array', () => {
+      const array = [1, 2, 3];
+      removeElementFromEndOfArray(array);
+      expect(array).to.eql([1, 2, 3]);
     })
   })
 })


### PR DESCRIPTION
@gj 

This PR addresses a couple of existing issues.

#42: Updates read me to ensure it is clear that the return value of `removeElementFromEndOfArray` should be the array without the last element (not the original array)
#17: Adds this test as well as another one that was missing. Also cleaned up the messages inside of the it functions to be consistent with one another and reduce confusion.